### PR TITLE
[FIX] admin_gods: (fields.W340) null has no effect on ManyToManyField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ Section Order:
 
 <!-- Your changes go here -->
 
+### Changed
+
+- God commands improved
+  - `/admin promote_to_god` Now promotes the user to god by adding them to the god group
+  - `/admin demote_from_god` Now demotes the user from god by removing them from the god group
+  - `/admin_demote_all_gods` (New) Demotes all users from god by removing them from the god group
+
 ## [3.2.0] - 2026-07-09
 
 > [!IMPORTANT]

--- a/tnnt_discordbot_cogs/locale/django.pot
+++ b/tnnt_discordbot_cogs/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: TN-NT Discordbot Cogs 3.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/tn-nt-discordbot-cogs/issues\n"
-"POT-Creation-Date: 2026-07-10 21:47+0200\n"
+"POT-Creation-Date: 2026-07-19 09:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -150,17 +150,17 @@ msgid ""
 "privileges."
 msgstr ""
 
-#: tnnt_discordbot_cogs/models/setting.py:157
+#: tnnt_discordbot_cogs/models/setting.py:156
 msgid ""
 "These users are eligible to invoke the god commands of the Discordbot to "
 "promote/demote themself to/from god."
 msgstr ""
 
-#: tnnt_discordbot_cogs/models/setting.py:168
+#: tnnt_discordbot_cogs/models/setting.py:167
 msgid "Setting"
 msgstr ""
 
-#: tnnt_discordbot_cogs/models/setting.py:169
-#: tnnt_discordbot_cogs/models/setting.py:179
+#: tnnt_discordbot_cogs/models/setting.py:168
+#: tnnt_discordbot_cogs/models/setting.py:178
 msgid "Settings"
 msgstr ""

--- a/tnnt_discordbot_cogs/migrations/0005_setting_admin_god_group.py
+++ b/tnnt_discordbot_cogs/migrations/0005_setting_admin_god_group.py
@@ -39,7 +39,6 @@ class Migration(migrations.Migration):
                     "These users are eligible to invoke the god commands of the "
                     "Discordbot to promote/demote themself to/from god."
                 ),
-                null=True,
                 related_name="admin_god",
                 to="authentication.user",
                 verbose_name="Admin Gods",

--- a/tnnt_discordbot_cogs/models/setting.py
+++ b/tnnt_discordbot_cogs/models/setting.py
@@ -150,7 +150,6 @@ class Setting(SingletonModel):
     admin_gods = models.ManyToManyField(
         to=User,
         related_name="admin_god",
-        null=True,
         blank=True,
         verbose_name=Field.ADMIN_GODS.label,
         help_text=_(


### PR DESCRIPTION
## Description

### Fixed

- tnnt_discordbot_cogs.Setting.admin_gods: (fields.W340) null has no effect on ManyToManyField

## Type of Change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
